### PR TITLE
Dynamo a Coordinate3D viewer and fixes to boxing

### DIFF
--- a/dynamo/convert/convert.py
+++ b/dynamo/convert/convert.py
@@ -200,7 +200,7 @@ def textFile2Coords(protocol, setTomograms, outPath):
     for tomo in setTomograms.iterItems():
         outPoints = pwutils.join(outPath, pwutils.removeBaseExt(tomo.getFileName()) + '.txt')
         outAngles = pwutils.join(outPath, 'angles_' + pwutils.removeBaseExt(tomo.getFileName()) + '.txt')
-        if not os.path.isfile(outPoints):
+        if not os.path.isfile(outPoints) or not os.path.isfile(outAngles):
             continue
 
         # Populate Set of 3D Coordinates with 3D Coordinates

--- a/dynamo/protocols/protocol_boxing.py
+++ b/dynamo/protocols/protocol_boxing.py
@@ -38,7 +38,7 @@ from tomo.viewers.views_tkinter_tree import TomogramsTreeProvider
 
 from dynamo import Plugin
 from dynamo.viewers.views_tkinter_tree import DynamoTomoDialog
-from dynamo.convert import eulerAngles2matrix
+from dynamo.convert import textFile2Coords
 
 class DynamoBoxing(ProtTomoPicking):
     """Manual vectorial picker from Dynamo. After choosing the Tomogram to be picked, the tomo slicer from Dynamo will be
@@ -146,39 +146,40 @@ class DynamoBoxing(ProtTomoPicking):
         pwutils.cleanPattern(self._getExtraPath('*.m'))
 
     def _createOutput(self):
-        coord3DSetDict = {}
-        setTomograms = self.inputTomograms.get()
-        suffix = self._getOutputSuffix(SetOfCoordinates3D)
-        coord3DSet = self._createSetOfCoordinates3D(setTomograms, suffix)
-        coord3DSet.setName("tomoCoord")
-        coord3DSet.setPrecedents(setTomograms)
-        coord3DSet.setSamplingRate(setTomograms.getSamplingRate())
-        coord3DSet.setBoxSize(self.boxSize.get())
-        for tomo in setTomograms.iterItems():
-            outPoints = pwutils.join(self._getExtraPath(), pwutils.removeBaseExt(tomo.getFileName()) + '.txt')
-            outAngles = pwutils.join(self._getExtraPath(), 'angles_' + pwutils.removeBaseExt(tomo.getFileName()) + '.txt')
-            if not os.path.isfile(outPoints):
-                continue
-
-            # Populate Set of 3D Coordinates with 3D Coordinates
-            points = np.loadtxt(outPoints, delimiter=' ')
-            angles = np.deg2rad(np.loadtxt(outAngles, delimiter=' '))
-            for idx in range(len(points)):
-                coord = Coordinate3D()
-                coord.setPosition(points[idx, 0], points[idx, 1], points[idx, 2])
-                matrix = eulerAngles2matrix(angles[idx, 0], angles[idx, 1], angles[idx, 2], 0, 0, 0)
-                coord.setMatrix(matrix)
-                coord.setVolume(tomo)
-                coord3DSet.append(coord)
-
-            coord3DSetDict['00'] = coord3DSet
-
-        name = self.OUTPUT_PREFIX + suffix
-        args = {}
-        args[name] = coord3DSet
-        self._defineOutputs(**args)
-        self._defineSourceRelation(setTomograms, coord3DSet)
-        self._updateOutputSet(name, coord3DSet, state=coord3DSet.STREAM_CLOSED)
+        textFile2Coords(self, self.inputTomograms.get(), self._getExtraPath())
+        # coord3DSetDict = {}
+        # setTomograms = self.inputTomograms.get()
+        # suffix = self._getOutputSuffix(SetOfCoordinates3D)
+        # coord3DSet = self._createSetOfCoordinates3D(setTomograms, suffix)
+        # coord3DSet.setName("tomoCoord")
+        # coord3DSet.setPrecedents(setTomograms)
+        # coord3DSet.setSamplingRate(setTomograms.getSamplingRate())
+        # coord3DSet.setBoxSize(self.boxSize.get())
+        # for tomo in setTomograms.iterItems():
+        #     outPoints = pwutils.join(self._getExtraPath(), pwutils.removeBaseExt(tomo.getFileName()) + '.txt')
+        #     outAngles = pwutils.join(self._getExtraPath(), 'angles_' + pwutils.removeBaseExt(tomo.getFileName()) + '.txt')
+        #     if not os.path.isfile(outPoints):
+        #         continue
+        #
+        #     # Populate Set of 3D Coordinates with 3D Coordinates
+        #     points = np.loadtxt(outPoints, delimiter=' ')
+        #     angles = np.deg2rad(np.loadtxt(outAngles, delimiter=' '))
+        #     for idx in range(len(points)):
+        #         coord = Coordinate3D()
+        #         coord.setPosition(points[idx, 0], points[idx, 1], points[idx, 2])
+        #         matrix = eulerAngles2matrix(angles[idx, 0], angles[idx, 1], angles[idx, 2], 0, 0, 0)
+        #         coord.setMatrix(matrix)
+        #         coord.setVolume(tomo)
+        #         coord3DSet.append(coord)
+        #
+        #     coord3DSetDict['00'] = coord3DSet
+        #
+        # name = self.OUTPUT_PREFIX + suffix
+        # args = {}
+        # args[name] = coord3DSet
+        # self._defineOutputs(**args)
+        # self._defineSourceRelation(setTomograms, coord3DSet)
+        # self._updateOutputSet(name, coord3DSet, state=coord3DSet.STREAM_CLOSED)
 
     # --------------------------- DEFINE info functions ----------------------
     def getMethods(self, output):

--- a/dynamo/protocols/protocol_boxing.py
+++ b/dynamo/protocols/protocol_boxing.py
@@ -38,7 +38,7 @@ from tomo.viewers.views_tkinter_tree import TomogramsTreeProvider
 
 from dynamo import Plugin
 from dynamo.viewers.views_tkinter_tree import DynamoTomoDialog
-from dynamo.convert import textFile2Coords
+from dynamo.convert import textFile2Coords, matrix2eulerAngles
 
 class DynamoBoxing(ProtTomoPicking):
     """Manual vectorial picker from Dynamo. After choosing the Tomogram to be picked, the tomo slicer from Dynamo will be
@@ -93,11 +93,16 @@ class DynamoBoxing(ProtTomoPicking):
             inputTomograms = self.inputTomograms.get()
             for tomo in inputTomograms:
                 outFileCoord = self._getExtraPath(pwutils.removeBaseExt(tomo.getFileName())) + ".txt"
+                outFileAngle = self._getExtraPath('angles_' + pwutils.removeBaseExt(tomo.getFileName())) + ".txt"
                 coords_tomo = []
+                angles_tomo = []
                 for coord in inputCoordinates.iterCoordinates(tomo):
                     coords_tomo.append(coord.getPosition())
+                    angles_shifts = matrix2eulerAngles(coord.getMatrix())
+                    angles_tomo.append(angles_shifts[:3])
                 if coords_tomo:
                     np.savetxt(outFileCoord, np.asarray(coords_tomo), delimiter=' ')
+                    np.savetxt(outFileAngle, np.asarray(angles_tomo), delimiter=' ')
 
             # Create small program to tell Dynamo to save the inputCoordinates in a Vesicle Model
             contents = "dcm -create %s -fromvll %s\n" \

--- a/dynamo/viewers/viewers_data.py
+++ b/dynamo/viewers/viewers_data.py
@@ -25,15 +25,22 @@
 # **************************************************************************
 
 import os
+import numpy as np
 
 from pwem.viewers import ObjectView
 
 import pyworkflow.viewer as pwviewer
+import pyworkflow.utils as pwutils
+from pyworkflow.gui.dialog import askYesNo
+from pyworkflow.utils.properties import Message
+from pyworkflow.utils.process import runJob
 
 import tomo.objects
-from tomo.viewers.views_tkinter_tree import MeshesTreeProvider
+from tomo.viewers.views_tkinter_tree import MeshesTreeProvider, TomogramsTreeProvider
 
-from dynamo.viewers.views_tkinter_tree import DynamoDialog
+from dynamo.viewers.views_tkinter_tree import DynamoDialog, DynamoTomoDialog
+from dynamo.convert import textFile2Coords
+from dynamo import Plugin
 
 
 
@@ -43,7 +50,8 @@ class DynamoDataViewer(pwviewer.Viewer):
     """
     _environments = [pwviewer.DESKTOP_TKINTER]
     _targets = [
-        tomo.objects.SetOfMeshes
+        tomo.objects.SetOfMeshes,
+        tomo.objects.SetOfCoordinates3D
     ]
 
     def __init__(self, **kwargs):
@@ -75,5 +83,76 @@ class DynamoDataViewer(pwviewer.Viewer):
             meshProvider = MeshesTreeProvider(meshList,)
 
             setView = DynamoDialog(self._tkRoot, path, True, provider=meshProvider,)
+
+        elif issubclass(cls, tomo.objects.SetOfCoordinates3D):
+            outputCoords = obj
+            tomos = outputCoords.getPrecedents()
+
+            tomoList = [item.clone() for item in tomos.iterItems()]
+
+            path = self.protocol._getTmpPath()
+
+            tomoProvider = TomogramsTreeProvider(tomoList, path, 'txt', )
+
+            listTomosFile = os.path.join(path, "tomos.vll")
+            catalogue = os.path.abspath(os.path.join(path, "tomos"))
+
+            # Create list of tomos file
+            tomoFid = open(listTomosFile, 'w')
+            for tomogram in tomos.iterItems():
+                tomoPath = os.path.abspath(tomogram.getFileName())
+                tomoFid.write(tomoPath + '\n')
+            tomoFid.close()
+
+            for tomogram in tomos:
+                outFileCoord = os.path.join(path, pwutils.removeBaseExt(tomogram.getFileName())) + ".txt"
+                coords_tomo = []
+                for coord in outputCoords.iterCoordinates(tomogram):
+                    coords_tomo.append(coord.getPosition())
+                if coords_tomo:
+                    np.savetxt(outFileCoord, np.asarray(coords_tomo), delimiter=' ')
+
+            codeFile = os.path.join(path, 'coords2model.m')
+            # Create small program to tell Dynamo to save the coordinates in a Vesicle Model
+            contents = "h=waitbar(0,'Please wait, loading data in Dynamo...')\n" \
+                       "dcm -create %s -fromvll %s\n" \
+                       "path='%s'\n" \
+                       "catalogue=dread(['%s' '.ctlg'])\n" \
+                       "nVolumes=length(catalogue.volumes)\n" \
+                       "for idv=1:nVolumes\n" \
+                       "tomoPath=catalogue.volumes{idv}.fullFileName()\n" \
+                       "tomoIndex=catalogue.volumes{idv}.index\n" \
+                       "[~,tomoName,~]=fileparts(tomoPath)\n" \
+                       "coordFile=[path '/' tomoName '.txt']\n" \
+                       "if ~isfile(coordFile)\n" \
+                       "waitbar(idv/nVolumes,h)\n" \
+                       "continue\n" \
+                       "end\n" \
+                       "coords=readmatrix(coordFile,'Delimiter',' ')\n" \
+                       "vesicle=dmodels.vesicle()\n" \
+                       "addPoint(vesicle,coords(:,1:3),coords(:,3))\n" \
+                       "vesicle.linkCatalogue('%s','i',tomoIndex, 's', 1)\n" \
+                       "vesicle.saveInCatalogue()\n" \
+                       "waitbar(idv/nVolumes,h)\n" \
+                       "end\n" \
+                       "delete(h)\n" \
+                       "exit\n" % (catalogue, listTomosFile, path, catalogue, catalogue)
+
+            codeFid = open(codeFile, 'w')
+            codeFid.write(contents)
+            codeFid.close()
+
+            args = ' %s' % codeFile
+            print(os.getcwd())
+            runJob(None, Plugin.getDynamoProgram(), args, env=Plugin.getEnviron())
+
+            self.dlg = DynamoTomoDialog(self._tkRoot, path, provider=tomoProvider)
+
+            import tkinter as tk
+            frame = tk.Frame()
+            if askYesNo(Message.TITLE_SAVE_OUTPUT, Message.LABEL_SAVE_OUTPUT, frame):
+                textFile2Coords(self.protocol, outputCoords.getPrecedents(), path)
+
+            pwutils.cleanPattern(os.path.join(path, '*'))
 
         return views

--- a/dynamo/viewers/viewers_data.py
+++ b/dynamo/viewers/viewers_data.py
@@ -39,7 +39,7 @@ import tomo.objects
 from tomo.viewers.views_tkinter_tree import MeshesTreeProvider, TomogramsTreeProvider
 
 from dynamo.viewers.views_tkinter_tree import DynamoDialog, DynamoTomoDialog
-from dynamo.convert import textFile2Coords
+from dynamo.convert import textFile2Coords, matrix2eulerAngles
 from dynamo import Plugin
 
 
@@ -99,18 +99,23 @@ class DynamoDataViewer(pwviewer.Viewer):
 
             # Create list of tomos file
             tomoFid = open(listTomosFile, 'w')
-            for tomogram in tomos.iterItems():
-                tomoPath = os.path.abspath(tomogram.getFileName())
+            for tomoFile in tomos.getFiles():
+                tomoPath = os.path.abspath(tomoFile)
                 tomoFid.write(tomoPath + '\n')
             tomoFid.close()
 
-            for tomogram in tomos:
+            for tomogram in tomoList:
                 outFileCoord = os.path.join(path, pwutils.removeBaseExt(tomogram.getFileName())) + ".txt"
+                outFileAngle = os.path.join(path, 'angles_' + pwutils.removeBaseExt(tomogram.getFileName())) + ".txt"
                 coords_tomo = []
+                angles_tomo = []
                 for coord in outputCoords.iterCoordinates(tomogram):
                     coords_tomo.append(coord.getPosition())
+                    angles_shifts = matrix2eulerAngles(coord.getMatrix())
+                    angles_tomo.append(angles_shifts[:3])
                 if coords_tomo:
                     np.savetxt(outFileCoord, np.asarray(coords_tomo), delimiter=' ')
+                    np.savetxt(outFileAngle, np.asarray(angles_tomo), delimiter=' ')
 
             codeFile = os.path.join(path, 'coords2model.m')
             # Create small program to tell Dynamo to save the coordinates in a Vesicle Model

--- a/dynamo/viewers/views_tkinter_tree.py
+++ b/dynamo/viewers/views_tkinter_tree.py
@@ -259,7 +259,7 @@ class DynamoTomoDialog(ToolbarListDialog):
                   "c=dread(strcat(catalogue_name,'.ctlg'))\n" \
                   "n=cellfun(@(c) c.fullFileName,c.volumes,'UniformOutput',false)\n" \
                   "idt=find(cell2mat(cellfun(@(c) strcmp(c,'%s'),n,'UniformOutput',false)))\n" \
-                  "dtmslice %s -c %s \n" \
+                  "eval(strcat('dtmslice @{%s}',num2str(idt)))\n" \
                   "modeltrack.loadFromCatalogue('handles',c,'full',true,'select',false)\n" \
                   "uiwait(dpkslicer.getHandles().figure_fastslicer)\n" \
                   "models = dread(dcmodels(catalogue_name,'i', idt))\n" \
@@ -282,7 +282,7 @@ class DynamoTomoDialog(ToolbarListDialog):
                   "writematrix(crop_points,fullfile(savePath,outPoints),'Delimiter',' ')\n" \
                   "writematrix(crop_angles,fullfile(savePath,outAngles),'Delimiter',' ')\n" \
                   "end\n" \
-                  'exit\n' % (catalogue, tomo.getFileName(), tomo.getFileName(), catalogue,
+                  'exit\n' % (catalogue, os.path.abspath(tomo.getFileName()), catalogue,
                             pwutils.removeBaseExt(tomo.getFileName()), self.path)
         codeFid.write(content)
         codeFid.close()


### PR DESCRIPTION
- Added the possibility to use Dynamo to visualize a `SetOfCoordinates3D`. The viewer allows to select the coordinates associated with a given `Tomogram` and to save any modification applied during the session as a new `SetOfCoordinates3D`.

- `protocol_boxing` bug fixes. Now opening previously generated coordinates will not lead to empty models in Dynamo.