### PR TITLE
Several Changes in Dynamo workflow

### DIFF
--- a/dynamo/protocols/protocol_models.py
+++ b/dynamo/protocols/protocol_models.py
@@ -85,12 +85,13 @@ class DynamoModels(ProtAnalysis3D, ProtTomoBase):
             outFile = self._getExtraPath(tomoName + '.txt')
             if os.path.isfile(outFile):
                 data = np.loadtxt(outFile, delimiter=',')
-                groups = np.unique(data[:, 3]).astype(int)
-                for group in groups:
-                    mesh = Mesh(group=group, path=outFile)
-                    mesh.setVolume(tomo.clone())
+                for coord in data:
+                    mesh = Mesh()
+                    mesh.setPosition(coord[0], coord[1], coord[2])
+                    mesh.setGroupId(coord[3])
+                    mesh.setVolume(tomo)
                     outSet.append(mesh)
-        outSet.setVolumes(self.inputTomograms.get())
+        outSet.setPrecedents(self.inputTomograms.get())
         name = self.OUTPUT_PREFIX
         args = {name: outSet}
         self._defineOutputs(**args)

--- a/dynamo/protocols/protocol_models.py
+++ b/dynamo/protocols/protocol_models.py
@@ -36,7 +36,7 @@ from pyworkflow.utils.properties import Message
 from dynamo.viewers.views_tkinter_tree import DynamoDialog
 
 from tomo.viewers.views_tkinter_tree import TomogramsTreeProvider
-from tomo.objects import Mesh
+from tomo.objects import MeshPoint
 from tomo.protocols import ProtTomoBase
 
 
@@ -86,7 +86,7 @@ class DynamoModels(ProtAnalysis3D, ProtTomoBase):
             if os.path.isfile(outFile):
                 data = np.loadtxt(outFile, delimiter=',')
                 for coord in data:
-                    mesh = Mesh()
+                    mesh = MeshPoint()
                     mesh.setPosition(coord[0], coord[1], coord[2])
                     mesh.setGroupId(coord[3])
                     mesh.setVolume(tomo)

--- a/dynamo/viewers/viewers_data.py
+++ b/dynamo/viewers/viewers_data.py
@@ -66,25 +66,25 @@ class DynamoDataViewer(pwviewer.Viewer):
         views = []
         cls = type(obj)
 
-        if issubclass(cls, tomo.objects.SetOfMeshes):
-            outputMeshes = obj
+        # if issubclass(cls, tomo.objects.SetOfMeshes):
+        #     outputMeshes = obj
+        #
+        #     # meshList = [item.clone() for item in outputMeshes.iterItems()]
+        #
+        #     meshList = []
+        #     for item in obj.iterItems():
+        #         mesh = item.clone()
+        #         mesh.setVolume(item.getVolume().clone())
+        #         meshList.append(mesh)
+        #     # meshList.reverse()
+        #
+        #     path = self.protocol._getExtraPath()
+        #
+        #     meshProvider = MeshesTreeProvider(meshList,)
+        #
+        #     setView = DynamoDialog(self._tkRoot, path, True, provider=meshProvider,)
 
-            # meshList = [item.clone() for item in outputMeshes.iterItems()]
-
-            meshList = []
-            for item in obj.iterItems():
-                mesh = item.clone()
-                mesh.setVolume(item.getVolume().clone())
-                meshList.append(mesh)
-            # meshList.reverse()
-
-            path = self.protocol._getExtraPath()
-
-            meshProvider = MeshesTreeProvider(meshList,)
-
-            setView = DynamoDialog(self._tkRoot, path, True, provider=meshProvider,)
-
-        elif issubclass(cls, tomo.objects.SetOfCoordinates3D):
+        if issubclass(cls, tomo.objects.SetOfCoordinates3D) or issubclass(cls, tomo.objects.SetOfMeshes):
             outputCoords = obj
             tomos = outputCoords.getPrecedents()
 


### PR DESCRIPTION
- Picking has been modified. The output now consists of a SetOfMehses defined by the "user points" defined in Dynamo tomo slice GUI.  The output generation has been modified to work with the new changes added to Mesh objects in [scipio-em-tomo](https://github.com/scipion-em/scipion-em-tomo/pull/97).
- New protocol to automatically apply a model workflow in Dynamo based on the input parameters specified by the user. Currently, only the ellipsoidal vesicle model is supported. The protocol receives the SetOfMeshes generated by the picking in Dynamo (extended with a catalogue path) to find and create a series of cropping meshes from the corresponding models. The output of this protocol is a SetOfCoordinates3D appropriate for the extraction of subtomograms.
- New SubBoxing protocol added d to Scipion. This program adds the capability of picking new coordinates around the points defined in a SetOfCoordinates3D given a distance (GUI) and a symmetry group type.