### PR TITLE
Fixes and new funcitonalities

### DIFF
--- a/dynamo/__init__.py
+++ b/dynamo/__init__.py
@@ -29,7 +29,7 @@ import pwem
 import pyworkflow.utils as pwutils
 from .constants import *
 
-__version__ = '3.1.5'
+__version__ = '3.1.6'
 _logo = "icon.png"
 _references = ['CASTANODIEZ2012139']
 

--- a/dynamo/convert/convert.py
+++ b/dynamo/convert/convert.py
@@ -215,7 +215,7 @@ def readDynCatalogue(ctlg_path, save_path):
               "s.volumes{idv}=struct(volumes{idv})\n" \
               "end\n" \
               "save('%s','s','-v7');" % (os.path.abspath(ctlg_path),
-                                           os.path.abspath(matPath))
+                                         os.path.abspath(matPath))
     codeFid.write(content)
     codeFid.close()
     args = ' %s' % codeFilePath
@@ -245,7 +245,7 @@ def textFile2Coords(protocol, setTomograms, outPath, directions=True, mesh=False
 
         # Populate Set of 3D Coordinates with 3D Coordinates
         points = np.loadtxt(outPoints, delimiter=' ')
-        angles = np.deg2rad(np.loadtxt(outAngles, delimiter=' ')) if directions else None
+        angles = np.loadtxt(outAngles, delimiter=' ') if directions else None
         for idx in range(len(points)):
             if mesh:
                 coord = MeshPoint()

--- a/dynamo/protocols.conf
+++ b/dynamo/protocols.conf
@@ -16,7 +16,9 @@ Tomography = [
             {"tag": "protocol", "value": "DynamoSubBoxing",   "text": "default"}
         ]}
     ]},
-    {"tag": "section", "text": "Preprocessing", "children": []},
+    {"tag": "section", "text": "Preprocessing", "children": [
+        {"tag": "protocol", "value": "DynamoBinTomograms", "text": "default"}
+    ]},
     {"tag": "section", "text": "Subtomogram averaging", "children": [
         {"tag": "protocol", "value": "DynamoSubTomoMRA", "text": "default"}
     ]}

--- a/dynamo/protocols/__init__.py
+++ b/dynamo/protocols/__init__.py
@@ -32,3 +32,4 @@ from .protocol_import_subtomos import DynamoImportSubtomos
 from .protocol_subBoxing import DynamoSubBoxing
 from .protocol_model_workflow import DynamoModelWorkflow
 from .protocol_import_tomograms import DynamoImportTomograms
+from .protocol_bin_tomograms import DynamoBinTomograms

--- a/dynamo/protocols/protocol_bin_tomograms.py
+++ b/dynamo/protocols/protocol_bin_tomograms.py
@@ -1,0 +1,137 @@
+# **************************************************************************
+# *
+# * Authors:    David Herreros Calero (dherreros@cnb.csic.es)
+# *
+# *  BCU, Centro Nacional de Biotecnologia, CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+
+import os
+
+from pyworkflow import BETA
+from pyworkflow.protocol import params, STEPS_PARALLEL
+import pyworkflow.utils as pwutils
+
+from pwem.protocols import EMProtocol
+
+from tomo.protocols import ProtTomoBase
+from tomo.objects import Tomogram
+
+from dynamo import Plugin
+
+
+class DynamoBinTomograms(EMProtocol, ProtTomoBase):
+    """Reduce the size of a SetOfTomograms by a binning factor"""
+
+    _label = 'bin tomograms'
+    _devStatus = BETA
+
+    OUTPUT_PREFIX = 'resizedTomograms'
+
+    def __init__(self, **kwargs):
+        EMProtocol.__init__(self, **kwargs)
+        self.stepsExecutionMode = STEPS_PARALLEL
+
+   # --------------------------- DEFINE param functions ----------------------
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputTomos', params.PointerParam, pointerClass='SetOfTomograms',
+                      label="Input Tomograms", important=True,
+                      help="Select the input tomograms to be resized.")
+        form.addParam('binning', params.IntParam, default=2,
+                      label="Binning Factor",
+                      help="Binning Factor to be applied to the Tomograms. A Binning Factor of 1 will decrease the "
+                           "size of the Tomograms by 2, a Binning Factor of 2 by 4...")
+        form.addParam('zChunk', params.IntParam, default=300, expertLevel=params.LEVEL_ADVANCED,
+                      label="Number of slices kept in memory",
+                      help="Maximum number of Z slices that are kept simultaneously in the memory during the "
+                           "binning process. This parameter might be important for larger size tomograms.")
+        form.addParallelSection(threads=4, mpi=1)
+
+    # --------------------------- INSERT steps functions ----------------------
+    def _insertAllSteps(self):
+        binning_steps = []
+        self.inputTomos = self.inputTomos.get()
+        for tomo in self.inputTomos:
+            binning_steps.append(self._insertFunctionStep('binTomosStep',
+                                                          tomo.getFileName(), tomo.getObjId()))
+        self._insertFunctionStep('createOutputStep', prerequisites=binning_steps)
+
+    # --------------------------- STEPS functions -----------------------------
+    def binTomosStep(self, tomoName, tomoId):
+        commandsFile = self.writeMatlabFile(os.path.abspath(tomoName), tomoId)
+        args = ' %s' % commandsFile
+        self.runJob(Plugin.getDynamoProgram(), args, env=Plugin.getEnviron())
+
+    def createOutputStep(self):
+        # Create a Volume template object
+        binning = self.binning.get()
+        sr = self.inputTomos.getSamplingRate() * 2 ** binning
+        tomo = Tomogram()
+        tomo.setSamplingRate(sr)
+        binned_tomos = self._createSetOfTomograms()
+        binned_tomos.setSamplingRate(sr)
+
+        for inTomo in self.inputTomos:
+            inTomo_file = inTomo.getFileName()
+            binned_scipion_name = pwutils.removeBaseExt(inTomo_file) + '_binned{}'.format(binning) + \
+                                  pwutils.getExt(inTomo_file)
+            binned_scipion_path = self._getExtraPath(binned_scipion_name)
+            tomo.cleanObjId()
+            tomo.setLocation(binned_scipion_path)
+            tomo.setOrigin(inTomo.getOrigin())
+            binned_tomos.append(tomo)
+
+        args = {self.OUTPUT_PREFIX: binned_tomos}
+        self._defineOutputs(**args)
+        self._defineSourceRelation(self.inputTomos, binned_tomos)
+
+    # --------------------------- DEFINE utils functions ----------------------
+    def writeMatlabFile(self, tomoPath, tomoId):
+        codeFilePath = self._getExtraPath('bin_Tomo_%d.m' % tomoId)
+        binned_scipion_name = pwutils.removeBaseExt(tomoPath) + '_binned{}'.format(self.binning.get()) + \
+                              pwutils.getExt(tomoPath)
+        binned_scipion_path = os.path.abspath(self._getExtraPath(binned_scipion_name))
+        content = "dpktomo.tools.bin('%s','%s',%d,'ss',%d)\n" \
+                  "exit\n" % (tomoPath, binned_scipion_path, self.binning.get(), self.zChunk.get())
+        codeFid = open(codeFilePath, 'w')
+        codeFid.write(content)
+        codeFid.close()
+        return codeFilePath
+
+    # --------------------------- DEFINE info functions ----------------------
+    def _methods(self):
+        methodsMsgs = []
+        methodsMsgs.append("*Binning Factor*: %s" % self.binning.get())
+        return methodsMsgs
+
+    def _summary(self):
+        summary = []
+        if self.getOutputsSize() >= 1:
+            for _, outTomos in self.iterOutputAttributes():
+                summary.append("Output *%s*:" % outTomos.getNameId().split('.')[1])
+                summary.append("    * Binning Factor: *%s*" % self.binning.get())
+                summary.append("    * Number of Tomograms Binned: *%s*" %
+                               outTomos.getSize())
+        else:
+            summary.append("Output tomograms not ready yet.")
+        return summary

--- a/dynamo/protocols/protocol_boxing.py
+++ b/dynamo/protocols/protocol_boxing.py
@@ -54,6 +54,8 @@ class DynamoBoxing(ProtTomoPicking):
     _label = 'vectorial picking'
     _devStatus = BETA
 
+    modelChoices = ["Ellipsoidal vesicle", "Surface"]
+    modelNames = {modelChoices[0]: "ellipsoidalVesicle", modelChoices[1]: "surface"}
     OUTPUT_PREFIX = 'outputMeshes'
 
     def __init__(self, **kwargs):
@@ -70,6 +72,10 @@ class DynamoBoxing(ProtTomoPicking):
         form.addParam('inputMeshes', PointerParam, label="Input Meshes", condition='selection == 0',
                       allowsNull=True, pointerClass='SetOfMeshes',
                       help='Select the previous SetOfMeshes you want to modify')
+        form.addParam('modelType', EnumParam,
+                      choices=self.modelChoices, default=0,
+                      label='Model type',
+                      help='Select the type of model defined in the Tomograms.')
 
     # --------------------------- INSERT steps functions ----------------------
     def _insertAllSteps(self):
@@ -124,14 +130,15 @@ class DynamoBoxing(ProtTomoPicking):
                        "for idm=idm_vec\n" \
                        "model_name=['model_',num2str(idm)]\n" \
                        "coords=coords_ids(coords_ids(:,4)==idm,1:3)\n" \
-                       "vesicle=dmodels.ellipsoidalVesicle()\n" \
+                       "vesicle=dmodels.%s()\n" \
                        "vesicle.name=model_name\n" \
                        "addPoint(vesicle,coords(:,1:3),coords(:,3))\n" \
                        "vesicle.linkCatalogue('%s','i',tomoIndex,'s',1)\n" \
                        "vesicle.saveInCatalogue()\n" \
                        "end\n" \
                        "end\n" \
-                       "exit\n" % (catalogue, listTomosFile, os.path.abspath(self._getExtraPath()), catalogue, catalogue)
+                       "exit\n" % (catalogue, listTomosFile, os.path.abspath(self._getExtraPath()), catalogue,
+                                   self.modelNames[self.modelChoices[self.modelType.get()]], catalogue)
         else:
             contents = "dcm -create %s -fromvll %s\n" % (catalogue, listTomosFile)
 

--- a/dynamo/protocols/protocol_boxing.py
+++ b/dynamo/protocols/protocol_boxing.py
@@ -54,8 +54,8 @@ class DynamoBoxing(ProtTomoPicking):
     _label = 'vectorial picking'
     _devStatus = BETA
 
-    modelChoices = ["Ellipsoidal vesicle", "Surface"]
-    modelNames = {modelChoices[0]: "ellipsoidalVesicle", modelChoices[1]: "surface"}
+    modelChoices = ["Ellipsoidal Vesicle", "Surface", "General"]
+    modelNames = {modelChoices[0]: "ellipsoidalVesicle", modelChoices[1]: "surface", modelChoices[2]: "general"}
     OUTPUT_PREFIX = 'outputMeshes'
 
     def __init__(self, **kwargs):

--- a/dynamo/protocols/protocol_extraction.py
+++ b/dynamo/protocols/protocol_extraction.py
@@ -161,11 +161,12 @@ class DynamoExtraction(EMProtocol, ProtTomoBase):
         self.outputSubTomogramsSet = self._createSetOfSubTomograms(self._getOutputSuffix(SetOfSubTomograms))
         self.outputSubTomogramsSet.setSamplingRate(self.getInputTomograms().getSamplingRate() * self.downFactor.get())
         self.outputSubTomogramsSet.setCoordinates3D(self.inputCoordinates)
-        acquisition = TomoAcquisition()
-        acquisition.setAngleMin(self.getInputTomograms().getFirstItem().getAcquisition().getAngleMin())
-        acquisition.setAngleMax(self.getInputTomograms().getFirstItem().getAcquisition().getAngleMax())
-        acquisition.setStep(self.getInputTomograms().getFirstItem().getAcquisition().getStep())
-        self.outputSubTomogramsSet.setAcquisition(acquisition)
+        if self.getInputTomograms().getFirstItem().getAcquisition():
+            acquisition = TomoAcquisition()
+            acquisition.setAngleMin(self.getInputTomograms().getFirstItem().getAcquisition().getAngleMin())
+            acquisition.setAngleMax(self.getInputTomograms().getFirstItem().getAcquisition().getAngleMax())
+            acquisition.setStep(self.getInputTomograms().getFirstItem().getAcquisition().getStep())
+            self.outputSubTomogramsSet.setAcquisition(acquisition)
         for ind, tomoFile in enumerate(self.tomoFiles):
             cropPath = os.path.join(self._getExtraPath('Crop%d' % (ind+1)), '')
             if os.path.isdir(cropPath):

--- a/dynamo/protocols/protocol_import_tomograms.py
+++ b/dynamo/protocols/protocol_import_tomograms.py
@@ -23,8 +23,7 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-
-
+import numpy as np
 from pyworkflow import BETA
 import pyworkflow.protocol.params as params
 from pyworkflow.utils import Message
@@ -132,7 +131,8 @@ class DynamoImportTomograms(ProtTomoImportFiles):
         tdb = readDynCatalogue(self.ctgPath.get(), self._getExtraPath())
 
         # Append Catalogue Tomograms to output set
-        for idv, volume in enumerate(tdb.volumes):
+        volumes_structs = tdb.volumes if isinstance(tdb.volumes, np.ndarray) else [tdb.volumes]
+        for idv, volume in enumerate(volumes_structs):
             tomo.cleanObjId()
             tomo.setLocation(volume.file)
             x, y, z = tomo.getDim()

--- a/dynamo/protocols/protocol_model_workflow.py
+++ b/dynamo/protocols/protocol_model_workflow.py
@@ -158,7 +158,6 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
                                   self.maxTr.get())
         elif self.modelType.get() == 1:
             content = "path='%s'\n" \
-                      "auto=%i\n" \
                       "crop_points=[]\n" \
                       "crop_angles=[]\n" \
                       "modelId=0\n" \
@@ -188,7 +187,7 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
                       "end\n" \
                       "writematrix(crop_points,fullfile(savePath,outPoints),'Delimiter',' ')\n" \
                       "writematrix(crop_angles,fullfile(savePath,outAngles),'Delimiter',' ')\n" \
-                      "exit\n" % (catalogue_path, self.auto.get(), outPath, os.path.abspath(self._getExtraPath()),
+                      "exit\n" % (catalogue_path, outPath, os.path.abspath(self._getExtraPath()),
                                   volId, self.meshParameter.get(), self.cropping.get(),
                                   self.maxTr.get(), self.subDivision.get())
 

--- a/dynamo/protocols/protocol_model_workflow.py
+++ b/dynamo/protocols/protocol_model_workflow.py
@@ -46,8 +46,7 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
     _label = 'model workflow'
     _devStatus = BETA
 
-    modelChoices = ["Ellipsoidal vesicle", "Surface"]
-    modelNames = ["ellipsoidalVesicle"]
+    modelChoices = ["Ellipsoidal Vesicle", "Surface", "General"]
     OUTPUT_PREFIX = 'output3DCoordinates'
 
     def __init__(self, **kwargs):
@@ -66,28 +65,43 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
                        choices=self.modelChoices, default=0,
                        label='Model type',
                        help='Select the type of model defined in the Tomograms.')
-        form.addParam('auto', params.BooleanParam, default=True, condition="modelType == 0",
+        form.addParam('orientMesh', params.PointerParam, pointerClass='SetOfMeshes',
+                      label="Orientation Meshes", allowsNull=True, condition="modelType == 2",
+                      help="Specify if you will use a different SetOfMeshes to impart orientation to "
+                           "the *Input Meshes* provided before. If not provided, no directional information "
+                           "will be given to the output coordinates.")
+        form.addParam('orientType', params.EnumParam,
+                       choices=self.modelChoices[:-1], default=0, condition="modelType == 2",
+                       label='Model type for *Orientation Meshes*',
+                       help='Select the type of model defined in the Tomograms.')
+        form.addParam('auto', params.BooleanParam, default=True,
+                      condition="modelType == 0 or (modelType==2 and orientType==0)",
                       label="Auto detect geometry")
         form.addParam('center', params.NumericListParam, default='0 0 0',
-                      label='Center', condition='modelType==0 and auto==False',
+                      label='Center',
+                      condition='(modelType==0 and auto==False) or (modelType==2 and orientType==0 and auto==False)',
                       help='Center of globular models, or a point marking the interior part '
                            'of a membrane')
         form.addParam('radius', params.NumericListParam, default='10 10 10',
-                      label='radius XYZ', condition='modelType==0 or auto==False',
+                      label='radius XYZ',
+                      condition='(modelType==0 and auto==False) or (modelType==2 and orientType==0 and auto==False)',
                       help='Semi-axes for ellipsoidal vesicles')
         form.addParam('meshParameter', params.IntParam, default=5, label="Mesh parameter",
-                      condition='modelType==0 or modelType == 1',
+                      condition='(modelType==0 or modelType == 1) or (modelType==2 and orientType==0 or orientType==1)',
                       help='Intended mesh parameter for the "mesh" that supports the '
                            'depiction of the model')
-        form.addParam('maxTr', params.IntParam, default=100000, condition='modelType==0 or modelType == 1',
+        form.addParam('maxTr', params.IntParam, default=100000,
+                      condition='(modelType==0 or modelType == 1) or (modelType==2 and orientType==0 or orientType==1)',
                       label="Maximun number of triangles",
                       help='Maximum number of triangles allowed during generation of a depiction '
                            'mesh')
-        form.addParam('cropping', params.IntParam, default=10, condition='modelType==0 or modelType == 1',
+        form.addParam('cropping', params.IntParam, default=10,
+                      condition='(modelType==0 or modelType == 1)',
                       label="Cropping parameter",
                       help='Intended mesh parameter for the "crop_mesh" that defined a cropping '
                            'geometry on a surface')
-        form.addParam('subDivision', params.IntParam, default=2, condition='modelType==1',
+        form.addParam('subDivision', params.IntParam, default=2,
+                      condition='modelType==1 or (modelType==2 and orientType==1)',
                       label="Number of Subdivision steps",
                       help="Specifiy the number of times the Mesh geometry will be subdivided. This will increase the "
                            "number of triangles in the mesh, making it smoother. However, it will also increase the "
@@ -129,8 +143,8 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
                       "outPoints=[outFile '.txt']\n" \
                       "outAngles=['angles_' outFile '.txt']\n" \
                       "modelFile=dir(fullfile(path,'tomograms','volume_%d','models'))\n" \
-                      "modelFile = modelFile(~ismember({modelFile.name},{'.','..'}))\n" \
-                      "for k = 1:length(modelFile)\n" \
+                      "modelFile=modelFile(~ismember({modelFile.name},{'.','..'}))\n" \
+                      "for k=1:length(modelFile)\n" \
                       "modelId=modelId+1\n" \
                       "m=dread(fullfile(modelFile(k).folder,modelFile(k).name))\n" \
                       "if auto==1\n" \
@@ -166,8 +180,8 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
                       "outPoints=[outFile '.txt']\n" \
                       "outAngles=['angles_' outFile '.txt']\n" \
                       "modelFile=dir(fullfile(path,'tomograms','volume_%d','models'))\n" \
-                      "modelFile = modelFile(~ismember({modelFile.name},{'.','..'}))\n" \
-                      "for k = 1:length(modelFile)\n" \
+                      "modelFile=modelFile(~ismember({modelFile.name},{'.','..'}))\n" \
+                      "for k=1:length(modelFile)\n" \
                       "modelId=modelId+1\n" \
                       "m=dread(fullfile(modelFile(k).folder,modelFile(k).name))\n" \
                       "m.mesh_parameter=%d\n" \
@@ -190,7 +204,113 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
                       "exit\n" % (catalogue_path, outPath, os.path.abspath(self._getExtraPath()),
                                   volId, self.meshParameter.get(), self.cropping.get(),
                                   self.maxTr.get(), self.subDivision.get())
-
+        elif self.modelType.get() == 2:
+            if self.orientType.get() == 0 and self.orientMesh.get() is not None:
+                center = pwutils.getFloatListFromValues(self.center.get())
+                radius = pwutils.getFloatListFromValues(self.radius.get())
+                orientation_mesh = os.path.abspath(pwutils.removeExt(self.orientMesh.get()._dynCatalogue.get()))
+                content = "path='%s'\n" \
+                          "path_o='%s'\n" \
+                          "auto=%i\n" \
+                          "crop_points=[]\n" \
+                          "crop_angles=[]\n" \
+                          "modelId=0\n" \
+                          "outFile='%s'\n" \
+                          "savePath='%s'\n" \
+                          "outPoints=[outFile '.txt']\n" \
+                          "outAngles=['angles_' outFile '.txt']\n" \
+                          "modelFile=dir(fullfile(path,'tomograms','volume_%d','models'))\n" \
+                          "modelFile=modelFile_o(~ismember({modelFile.name},{'.','..'}))\n" \
+                          "modelFile_o=dir(fullfile(path_o,'tomograms','volume_%d','models'))\n" \
+                          "modelFile_o=modelFile(~ismember({modelFile_o.name},{'.','..'}))\n" \
+                          "for k=1:length(modelFile)\n" \
+                          "modelId=modelId+1\n" \
+                          "m=dread(fullfile(modelFile(k).folder,modelFile(k).name))\n" \
+                          "m_o=dread(fullfile(modelFile_o(k).folder,modelFile_o(k).name))\n" \
+                          "if auto==1\n" \
+                          "m_o.approximateGeometryFromPoints()\n" \
+                          "else\n" \
+                          "m_o.center=[%f %f %f]\n" \
+                          "m_o.radius_x=%f\n" \
+                          "m_o.radius_y=%f\n" \
+                          "m_o.radius_z=%f\n" \
+                          "end\n" \
+                          "m_o.mesh_parameter=%d\n" \
+                          "m_o.mesh_maximum_triangles=%d\n" \
+                          "m_o.createMesh\n" \
+                          "t=m.grepTable()\n" \
+                          "t=dpktbl.triangulation.fillTable(m_o.mesh,t)\n" \
+                          "crop_points=[crop_points; [t(:,24:26) modelId*ones(length(m.crop_points),1)]]\n" \
+                          "crop_angles=[crop_angles; [t(:,7:9) modelId*ones(length(m.crop_angles),1)]]\n" \
+                          "end\n" \
+                          "writematrix(crop_points,fullfile(savePath,outPoints),'Delimiter',' ')\n" \
+                          "writematrix(crop_angles,fullfile(savePath,outAngles),'Delimiter',' ')\n" \
+                          "exit\n" % (catalogue_path, orientation_mesh, self.auto.get(), outPath,
+                                      os.path.abspath(self._getExtraPath()),
+                                      volId, volId, center[0], center[1], center[2], radius[0], radius[1],
+                                      radius[2], self.meshParameter.get(),
+                                      self.maxTr.get())
+            elif self.orientType.get() == 1 and self.orientMesh.get() is not None:
+                orientation_mesh = os.path.abspath(pwutils.removeExt(self.orientMesh.get()._dynCatalogue.get()))
+                content = "path='%s'\n" \
+                          "path_o='%s'\n" \
+                          "crop_points=[]\n" \
+                          "crop_angles=[]\n" \
+                          "modelId=0\n" \
+                          "outFile='%s'\n" \
+                          "savePath='%s'\n" \
+                          "outPoints=[outFile '.txt']\n" \
+                          "outAngles=['angles_' outFile '.txt']\n" \
+                          "modelFile=dir(fullfile(path,'tomograms','volume_%d','models'))\n" \
+                          "modelFile=modelFile(~ismember({modelFile.name},{'.','..'}))\n" \
+                          "modelFile_o=dir(fullfile(path_o,'tomograms','volume_%d','models'))\n" \
+                          "modelFile_o=modelFile_o(~ismember({modelFile_o.name},{'.','..'}))\n" \
+                          "for k=1:length(modelFile)\n" \
+                          "modelId=modelId+1\n" \
+                          "m=dread(fullfile(modelFile(k).folder,modelFile(k).name))\n" \
+                          "m_o=dread(fullfile(modelFile_o(k).folder,modelFile_o(k).name))\n" \
+                          "m_o.mesh_parameter=%d\n" \
+                          "m_o.mesh_maximum_triangles=%d\n" \
+                          "m_o.subdivision_iterations=%d\n" \
+                          "if isempty(m_o.center)\n" \
+                          "m_o.center=mean(m_o.points)\n" \
+                          "end\n" \
+                          "m_o.createMesh()\n" \
+                          "m_o.refineMesh()\n" \
+                          "t=m.grepTable()\n" \
+                          "t=dpktbl.triangulation.fillTable(m_o.mesh,t)\n" \
+                          "crop_points=[crop_points; [t(:,24:26) modelId*ones(length(m.crop_points),1)]]\n" \
+                          "crop_angles=[crop_angles; [t(:,7:9) modelId*ones(length(m.crop_angles),1)]]\n" \
+                          "end\n" \
+                          "writematrix(crop_points,fullfile(savePath,outPoints),'Delimiter',' ')\n" \
+                          "writematrix(crop_angles,fullfile(savePath,outAngles),'Delimiter',' ')\n" \
+                          "exit\n" % (catalogue_path, orientation_mesh, outPath,
+                                      os.path.abspath(self._getExtraPath()),
+                                      volId, volId, self.meshParameter.get(),
+                                      self.maxTr.get(), self.subDivision.get())
+            else:
+                content = "path='%s'\n" \
+                          "crop_points=[]\n" \
+                          "crop_angles=[]\n" \
+                          "modelId=0\n" \
+                          "outFile='%s'\n" \
+                          "savePath='%s'\n" \
+                          "outPoints=[outFile '.txt']\n" \
+                          "outAngles=['angles_' outFile '.txt']\n" \
+                          "modelFile=dir(fullfile(path,'tomograms','volume_%d','models'))\n" \
+                          "modelFile=modelFile(~ismember({modelFile.name},{'.','..'}))\n" \
+                          "for k=1:length(modelFile)\n" \
+                          "modelId=modelId+1\n" \
+                          "m=dread(fullfile(modelFile(k).folder,modelFile(k).name))\n" \
+                          "t=m.grepTable()\n" \
+                          "crop_points=[crop_points; [t(:,24:26) modelId*ones(length(m.crop_points),1)]]\n" \
+                          "crop_angles=[crop_angles; [t(:,7:9) modelId*ones(length(m.crop_angles),1)]]\n" \
+                          "end\n" \
+                          "writematrix(crop_points,fullfile(savePath,outPoints),'Delimiter',' ')\n" \
+                          "writematrix(crop_angles,fullfile(savePath,outAngles),'Delimiter',' ')\n" \
+                          "exit\n" % (catalogue_path, outPath,
+                                      os.path.abspath(self._getExtraPath()),
+                                      volId)
         codeFid = open(codeFilePath, 'w')
         codeFid.write(content)
         codeFid.close()
@@ -199,16 +319,42 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
     # --------------------------- DEFINE info functions ----------------------
     def _methods(self):
         methodsMsgs = []
-        methodsMsgs.append("*Mesh type*: %s" % self.modelType.get())
-        if self.auto.get():
-            methodsMsgs.append("*Geomtry Detection*: auto")
-        else:
-            methodsMsgs.append("*Geomtry Detection*: manual")
-            methodsMsgs.append("    *Center*: [%s]" % self.center.get())
-            methodsMsgs.append("    *Semiaxes Radius*: [%s]" % self.radius.get())
-        methodsMsgs.append("*Mesh parameter*: %d" % self.meshParameter.get())
-        methodsMsgs.append("*Maximum number triangles*: %d" % self.maxTr.get())
-        methodsMsgs.append("*Cropping parameter*: %d" % self.cropping.get())
+        methodsMsgs.append("*Model Type*: %s" % self.modelChoices[self.modelType.get()])
+        if self.modelType.get() == 0:
+            if self.auto.get():
+                methodsMsgs.append("*Geometry Detection*: auto")
+            else:
+                methodsMsgs.append("*Geometry Detection*: manual")
+                methodsMsgs.append("    *Center*: [%s]" % self.center.get())
+                methodsMsgs.append("    *Semiaxes Radius*: [%s]" % self.radius.get())
+            methodsMsgs.append("*Mesh parameter*: %d" % self.meshParameter.get())
+            methodsMsgs.append("*Maximum number triangles*: %d" % self.maxTr.get())
+            methodsMsgs.append("*Cropping parameter*: %d" % self.cropping.get())
+        elif self.modelType.get() == 1:
+            methodsMsgs.append("*Model Type*: Surface")
+            methodsMsgs.append("*Mesh parameter*: %d" % self.meshParameter.get())
+            methodsMsgs.append("*Maximum number triangles*: %d" % self.maxTr.get())
+            methodsMsgs.append("*Cropping parameter*: %d" % self.cropping.get())
+            methodsMsgs.append("*Number of subdivision steps*: %d" % self.subDivision.get())
+        elif self.modelType.get() == 2:
+            if self.orientMesh.get() is None:
+                methodsMsgs.append("Particles extracted without orientation")
+            else:
+                if self.orientType.get() == 0:
+                    methodsMsgs.append("*Orientation Model Type*: Ellipsoidal Vesicle")
+                    if self.auto.get():
+                        methodsMsgs.append("*Geometry Detection*: auto")
+                    else:
+                        methodsMsgs.append("*Geometry Detection*: manual")
+                        methodsMsgs.append("    *Center*: [%s]" % self.center.get())
+                        methodsMsgs.append("    *Semiaxes Radius*: [%s]" % self.radius.get())
+                    methodsMsgs.append("*Mesh parameter*: %d" % self.meshParameter.get())
+                    methodsMsgs.append("*Maximum number triangles*: %d" % self.maxTr.get())
+                elif self.orientType.get() == 1:
+                    methodsMsgs.append("*Orientation Model Type*: Surface")
+                    methodsMsgs.append("*Mesh parameter*: %d" % self.meshParameter.get())
+                    methodsMsgs.append("*Maximum number triangles*: %d" % self.maxTr.get())
+                    methodsMsgs.append("*Number of subdivision steps*: %d" % self.subDivision.get())
         return methodsMsgs
 
     def _summary(self):

--- a/dynamo/protocols/protocol_model_workflow.py
+++ b/dynamo/protocols/protocol_model_workflow.py
@@ -27,7 +27,6 @@
 
 import os
 
-import param
 from pyworkflow import BETA
 from pyworkflow.protocol import params
 import pyworkflow.utils as pwutils

--- a/dynamo/protocols/protocol_model_workflow.py
+++ b/dynamo/protocols/protocol_model_workflow.py
@@ -175,7 +175,9 @@ class DynamoModelWorkflow(EMProtocol, ProtTomoBase):
                       "m.crop_mesh_parameter=%d\n" \
                       "m.mesh_maximum_triangles=%d\n" \
                       "m.subdivision_iterations=%d\n" \
+                      "if isempty(m.center)\n" \
                       "m.center=mean(m.points)\n" \
+                      "end\n" \
                       "m.createMesh()\n" \
                       "m.refineMesh()\n" \
                       "m.createCropMesh()\n" \


### PR DESCRIPTION
- Import Tomograms: Fixed an error arising when the `SetOfTomograms` used in the input had a single item.
- New binning protocol: New protocol for binning a  `SetOfTomograms` using Dynamo and Matlab.
- Boxing: Two new geometries are now supported
                          - `Surface`: Geometry to define a continuous object in the Tomogram that is not closed.
                          - `General`: Picking of only coordinates without any orientation
- Model workflow: Model workflow has been extended to be able to support the new geometries
                          - `Surface`: New Matlab script to create a `Mesh` based on a `Surface` geometry and extract the cropping coordinates
                          - `General`: Coordinates defined in the model can be extracted directly (no orientation mode). In addition, it is also possible to use another geometry (`Surface` or `Ellipsoidal Vesicle`) to impart an orientation to those manually picked coordinates based on a `Mesh`.