### PR TITLE
Dynamo: extraction fixes and protocols.conf

### DIFF
--- a/dynamo/protocols.conf
+++ b/dynamo/protocols.conf
@@ -1,26 +1,46 @@
 [PROTOCOLS]
 Tomography = [
 	{"tag": "section", "text": "Imports", "icon": "bookmark.png", "children": [
-        {"tag": "protocol", "value": "DynamoImportSubtomos", "text": "default"},
-        {"tag": "protocol", "value": "DynamoImportTomograms", "text": "default"}
-    ]},
-	{"tag": "section", "text": "Movies/Micrographs", "children": []},
-	{"tag": "section", "text": "Reconstruction", "children": []},
+	    {"tag": "protocol", "value": "DynamoImportSubtomos", "text": "default"},
+        {"tag": "protocol", "value": "DynamoImportTomograms", "text": "default"},
+        {"tag": "section", "text": "more", "openItem": "False", "children": []}
+	]},
+	{"tag": "section", "text": "Tilt-series movies", "children": []},
+	{"tag": "section", "text": "Tilt-series", "children":
+	[
+		{"tag": "protocol_group", "text": "Tilt-series preprocess", "openItem": "False", "children": []},
+		{"tag": "protocol_group", "text": "CTF", "openItem": "False", "children": []},
+		{"tag": "protocol_group", "text": "Tilt-series alignment", "openItem": "False", "children": []}
+	]},
+	{"tag": "section", "text": "Tomograms", "children":
+	[
+		{"tag": "protocol_group", "text": "Tomogram recontruction", "openItem": "False", "children": []},
+		{"tag": "protocol_group", "text": "Denoise", "openItem": "False", "children": []},
+		{"tag": "protocol_group", "text": "Segmentation", "openItem": "False", "children": []},
+		{"tag": "protocol_group", "text": "Tomogram postprocess", "openItem": "False", "children":
+		[
+			{"tag": "protocol", "value": "DynamoBinTomograms", "text": "default"}
+		]}
+	]},
 	{"tag": "section", "text": "Particles", "children": [
-        {"tag": "protocol_group", "text": "Extract", "openItem": "False", "children": [
-            {"tag": "protocol", "value": "DynamoExtraction",   "text": "default"}
-        ]},
-        {"tag": "protocol_group", "text": "Picking", "openItem": "False", "children": [
-            {"tag": "protocol", "value": "DynamoBoxing",   "text": "default"},
+		{"tag": "protocol_group", "text": "Picking", "openItem": "False", "children":
+		[
+		    {"tag": "protocol", "value": "DynamoBoxing",   "text": "default"},
             {"tag": "protocol", "value": "DynamoModelWorkflow",   "text": "default"},
-            {"tag": "protocol", "value": "DynamoSubBoxing",   "text": "default"}
-        ]}
+            {"tag": "protocol", "value": "DynamoSubBoxing",   "text": "default"},
+            {"tag": "protocol", "value": "DynamoCoordsToModel", "text": "default"}
+		]},
+		{"tag": "protocol_group", "text": "Extract", "openItem": "False", "children":
+		[
+		    {"tag": "protocol", "value": "DynamoExtraction",   "text": "default"}
+		]}
+	]},
+	{"tag": "section", "text": "Preprocessing", "children": []},
+    {"tag": "section", "text": "Subtomogram averaging", "children":
+    [
+        {"tag": "protocol", "value": "DynamoSubTomoMRA", "text": "default"},
+        {"tag": "protocol_group", "text": "Per tilt refinement", "openItem": "False", "children": []}
     ]},
-    {"tag": "section", "text": "Preprocessing", "children": [
-        {"tag": "protocol", "value": "DynamoBinTomograms", "text": "default"},
-        {"tag": "protocol", "value": "DynamoCoordsToModel", "text": "default"}
-    ]},
-    {"tag": "section", "text": "Subtomogram averaging", "children": [
-        {"tag": "protocol", "value": "DynamoSubTomoMRA", "text": "default"}
-    ]}
+    {"tag": "section", "text": "Postprocessing", "children": []},
+    {"tag": "section", "text": "Test", "children": []}
  ]

--- a/dynamo/protocols.conf
+++ b/dynamo/protocols.conf
@@ -2,21 +2,10 @@
 Tomography = [
 	{"tag": "section", "text": "Imports", "icon": "bookmark.png", "children": [
 	    {"tag": "protocol", "value": "DynamoImportSubtomos", "text": "default"},
-        {"tag": "protocol", "value": "DynamoImportTomograms", "text": "default"},
-        {"tag": "section", "text": "more", "openItem": "False", "children": []}
-	]},
-	{"tag": "section", "text": "Tilt-series movies", "children": []},
-	{"tag": "section", "text": "Tilt-series", "children":
-	[
-		{"tag": "protocol_group", "text": "Tilt-series preprocess", "openItem": "False", "children": []},
-		{"tag": "protocol_group", "text": "CTF", "openItem": "False", "children": []},
-		{"tag": "protocol_group", "text": "Tilt-series alignment", "openItem": "False", "children": []}
+        {"tag": "protocol", "value": "DynamoImportTomograms", "text": "default"}
 	]},
 	{"tag": "section", "text": "Tomograms", "children":
 	[
-		{"tag": "protocol_group", "text": "Tomogram recontruction", "openItem": "False", "children": []},
-		{"tag": "protocol_group", "text": "Denoise", "openItem": "False", "children": []},
-		{"tag": "protocol_group", "text": "Segmentation", "openItem": "False", "children": []},
 		{"tag": "protocol_group", "text": "Tomogram postprocess", "openItem": "False", "children":
 		[
 			{"tag": "protocol", "value": "DynamoBinTomograms", "text": "default"}
@@ -35,12 +24,9 @@ Tomography = [
 		    {"tag": "protocol", "value": "DynamoExtraction",   "text": "default"}
 		]}
 	]},
-	{"tag": "section", "text": "Preprocessing", "children": []},
     {"tag": "section", "text": "Subtomogram averaging", "children":
     [
         {"tag": "protocol", "value": "DynamoSubTomoMRA", "text": "default"},
         {"tag": "protocol_group", "text": "Per tilt refinement", "openItem": "False", "children": []}
-    ]},
-    {"tag": "section", "text": "Postprocessing", "children": []},
-    {"tag": "section", "text": "Test", "children": []}
+    ]}
  ]

--- a/dynamo/protocols/protocol_extraction.py
+++ b/dynamo/protocols/protocol_extraction.py
@@ -218,11 +218,11 @@ class DynamoExtraction(EMProtocol, ProtTomoBase):
                   "parfor(tag=unique(tags),%d)\n" \
                   "tomoCoords=coords(tags==tag,:)\n" \
                   "tomoAngles=angles(tags==tag,:)\n" \
-                  "t=dynamo_table_blank(size(tomoCoords,1),'r',tomoCoords,'angles',rad2deg(tomoAngles))\n" \
+                  "t=dynamo_table_blank(size(tomoCoords,1),'r',tomoCoords,'angles',tomoAngles)\n" \
                   "dtcrop(c.volumes{tag}.fullFileName,t,strcat(savePath,num2str(tag)),box,'ext','mrc')\n" \
                   "end\n" \
                    % (os.path.abspath(os.getcwd()), self._getExtraPath('Crop'),
-                      catalogue,boxSize, catalogue, listTomosFile, os.path.abspath(self.coordsFileName),
+                      catalogue, boxSize, catalogue, listTomosFile, os.path.abspath(self.coordsFileName),
                       os.path.abspath(self.anglesFileName), self.numberOfThreads.get())
 
         codeFid.write(content)


### PR DESCRIPTION
- `protocols.conf` has been modified to follow the new model designed for Scipion Tomo
- The Dynamo table generated during the extraction was not storing the alignment information properly. Although this did not introduce any bug in the output of the protocol itself. it led to errors when reimporting the coordinates stored in that table. The bug has been fixed to avoid this issue in the future.