### PR TITLE
dynamo MRA: Adding validation in Sampling and size 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,10 @@
-V3.3.0:
+V3.1.22:
+  - Binning tomograms protocol: fix bug.
+  - MRA protocol: add sampling rate validations.
+V3.1.21:
   - Prevent viewers from locking the screen focus.
-V3.2.20:
+V3.1.20:
   - Fix the setup file
-V3.2.20:
   - Subtomogram alignment: fix bug when using masks.
   - Subtomogram alignment: fix output problem when the alignment removed some particles.
 V3.1.19:

--- a/dynamo/__init__.py
+++ b/dynamo/__init__.py
@@ -31,7 +31,7 @@ import pyworkflow
 import pyworkflow.utils as pwutils
 from .constants import *
 
-__version__ = '3.3.0'
+__version__ = '3.1.22'
 _logo = "icon.png"
 _references = ['CASTANODIEZ2012139']
 

--- a/dynamo/protocols/protocol_subtomo_MRA.py
+++ b/dynamo/protocols/protocol_subtomo_MRA.py
@@ -118,7 +118,7 @@ class DynamoSubTomoMRA(ProtTomoSubtomogramAveraging):
                       label='Set of subtomograms',
                       help="Set of subtomograms to align with dynamo")
         form.addParam('templateRef', PointerParam,
-                      pointerClass='Volume, SubTomogram',
+                      pointerClass='Volume',
                       important=True,
                       label="Template",
                       help='The size of the template should be equal or smaller than the size of the particles.')  # If you '
@@ -767,13 +767,13 @@ class DynamoSubTomoMRA(ProtTomoSubtomogramAveraging):
         #                                 'size as the set of references')
 
         # Check the reference
-        if not self.sizesOk(subtomo):
+        if not self.sizesOk(subtomo, False):
             validateMsgs.append('The size of the template should be equal or smaller than the size of the particles.')
         # Check the masks
         if introducedMasks:
             for mask in masks:
                 if mask:
-                    if not self.sizesOk(mask):
+                    if not self.sizesOk(mask, False):
                         validateMsgs.append('The introduced masks must be of the same size as the template.')
                         break
         # Check the dims values

--- a/dynamo/protocols/protocol_subtomo_MRA.py
+++ b/dynamo/protocols/protocol_subtomo_MRA.py
@@ -722,6 +722,16 @@ class DynamoSubTomoMRA(ProtTomoSubtomogramAveraging):
         else:
             return testDims == refDims
 
+    def samplingOk(self):
+        samplingRef = self.templateRef.get().getSamplingRate()
+        samplingSubtomos = self.inputVolumes.get().getSamplingRate()
+        checkResult = False
+        tol = 0.005
+        if abs(samplingRef-samplingSubtomos) > tol:
+            return False
+        else:
+            return True
+
     @staticmethod
     def anyValActiveInNumListParam(iParam) -> bool:
         """Checks if any of the values of a NumericListParam is greater than 0, which means to
@@ -769,6 +779,10 @@ class DynamoSubTomoMRA(ProtTomoSubtomogramAveraging):
         # Check the reference
         if not self.sizesOk(subtomo, False):
             validateMsgs.append('The size of the template should be equal or smaller than the size of the particles.')
+        # Check sampling rate reference and subtomograms
+        if not self.samplingOk():
+            validateMsgs.append('The sampling of the subtomograms does not match with the sampling of the subtomograms.'
+                                'Please resample any of them')
         # Check the masks
         if introducedMasks:
             for mask in masks:

--- a/dynamo/protocols/protocol_subtomo_MRA.py
+++ b/dynamo/protocols/protocol_subtomo_MRA.py
@@ -778,7 +778,7 @@ class DynamoSubTomoMRA(ProtTomoSubtomogramAveraging):
 
         # Check the reference
         if not self.sizesOk(subtomo, False):
-            validateMsgs.append('The size of the template should be equal or smaller than the size of the particles.')
+            validateMsgs.append('The size of the template should be equal to the size of the particles.')
         # Check sampling rate reference and subtomograms
         if not self.samplingOk():
             validateMsgs.append('The sampling of the subtomograms does not match with the sampling of the subtomograms.'


### PR DESCRIPTION
The sampling or size of the reference must be equal to the subtomograms one. If sizes do not match, dynamo is able to work but produces non-sense results.

Example:

Left result of refinement with with the same size. Right with different sizes

![image](https://github.com/user-attachments/assets/5075c82d-ee70-4285-bf82-64cfe35db409)

Note: the result must be a donut
